### PR TITLE
#2 Fix traceability issue

### DIFF
--- a/gamification/src/main/resources/logback-spring.xml
+++ b/gamification/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <appender name="AMQP"
               class="org.springframework.amqp.rabbit.logback.AmqpAppender">
         <layout>
-            <pattern>%d{HH:mm:ss.SSS} [%t] %logger{36} - %msg</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [trace id: %X{traceId:-}, span id: %X{spanId:-}] [%t] %logger{36} - %msg</pattern>
         </layout>
 
         <applicationId>gamification</applicationId>

--- a/gateway/src/main/resources/logback-spring.xml
+++ b/gateway/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <appender name="AMQP"
               class="org.springframework.amqp.rabbit.logback.AmqpAppender">
         <layout>
-            <pattern>%d{HH:mm:ss.SSS} [%t] %logger{36} - %msg</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [trace id: %X{traceId:-}, span id: %X{spanId:-}] [%t] %logger{36} - %msg</pattern>
         </layout>
 
         <applicationId>gateway</applicationId>

--- a/logs/pom.xml
+++ b/logs/pom.xml
@@ -38,10 +38,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-sleuth</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-bootstrap</artifactId>
 		</dependency>
 

--- a/logs/src/main/resources/logback-spring.xml
+++ b/logs/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
-                [%-15marker] [%X{traceId:-},%X{spanId:-}] %highlight(%-5level) %msg%n
+                [%-15marker] %highlight(%-5level) %msg%n
             </Pattern>
         </layout>
     </appender>

--- a/multiplication/src/main/resources/logback-spring.xml
+++ b/multiplication/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <appender name="AMQP"
               class="org.springframework.amqp.rabbit.logback.AmqpAppender">
         <layout>
-            <pattern>%d{HH:mm:ss.SSS} [%t] %logger{36} - %msg</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [trace id: %X{traceId:-}, span id: %X{spanId:-}] [%t] %logger{36} - %msg</pattern>
         </layout>
 
         <applicationId>multiplication</applicationId>


### PR DESCRIPTION
After upgrading to Spring Boot 2.4 and Spring Cloud 2020.0, the trace id correlation doesn't work as before. Probably the logback's `AmqpAppender` provided by Spring is working differently. 

I don't think this is a bug in Spring; I was taking advantage of getting the same `traceId` values in the RabbitMQ messages consumed by the centralized logger, but this implementation was quite fragile.

What I'm doing now is simpler and more robust. Instead of getting the Sleuth metadata in the `logs` microservice, I'm just propagating it in the messages as they get produced. This way, I don't even need Sleuth in the centralized logger, which implementation should be kept as dumb as possible.