### PR TITLE
#1 Fix property source locations

### DIFF
--- a/gamification/src/main/resources/application.properties
+++ b/gamification/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-spring.application.name=gamification
 server.port=8081
 # Gives us access to the H2 database web console
 spring.h2.console.enabled=true

--- a/gamification/src/main/resources/bootstrap.properties
+++ b/gamification/src/main/resources/bootstrap.properties
@@ -1,3 +1,4 @@
+spring.application.name=gamification
 spring.cloud.consul.config.prefix=config
 spring.cloud.consul.config.format=yaml
 spring.cloud.consul.config.default-context=defaults

--- a/logs/src/main/resources/application.properties
+++ b/logs/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-spring.application.name=logs
 server.port=8580

--- a/logs/src/main/resources/bootstrap.properties
+++ b/logs/src/main/resources/bootstrap.properties
@@ -1,3 +1,4 @@
+spring.application.name=logs
 spring.cloud.consul.config.prefix=config
 spring.cloud.consul.config.format=yaml
 spring.cloud.consul.config.default-context=defaults

--- a/multiplication/src/main/resources/application.properties
+++ b/multiplication/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-spring.application.name=multiplication
 # Gives us access to the H2 database web console
 spring.h2.console.enabled=true
 # Creates the database in a file

--- a/multiplication/src/main/resources/bootstrap.properties
+++ b/multiplication/src/main/resources/bootstrap.properties
@@ -1,3 +1,4 @@
+spring.application.name=multiplication
 spring.cloud.consul.config.prefix=config
 spring.cloud.consul.config.format=yaml
 spring.cloud.consul.config.default-context=defaults


### PR DESCRIPTION
As reported in #1, the property sources are pointing to the wrong location after the upgrade to Spring Boot 2.4 and Spring Cloud 2020.0. 

This behavior seems to be related to the changes made in Spring Cloud 2020.0 to discourage the use of the bootstrap phase. Prior to the update, the `spring.application.name` in the `application.properties` file was used to compose the property source locations. After the update, this value doesn't seem to be loaded and a literal `application` value is used instead.

To fix this issue, I'm moving the `spring.application.name` to the `bootstrap.properties` file, where it maybe should have been from the beginning as it's a value that's used very early during the starting of the application.